### PR TITLE
chore: update ort to rc9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,22 +854,21 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e45a172e6c0fb7d640e92c7740f4ea476bfc49ef5c52ea9c73e9fae32b09fe"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
 dependencies = [
  "half",
  "ndarray",
  "ort-sys",
- "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6fe264a9467cd0c19cbee07afe689fae9480c4706c4a1a00b5e64ff99ea83a"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -1358,19 +1357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,11 @@ sonic-rs-sys = { path = "crates/sonic-rs-sys", version = "0.1.1" }
 ndarray = "0.16.1"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.89"
-ort = { version = "2.0.0-rc.1" }
+ort = { version = "2.0.0-rc.9" }
 once_cell = "1.18.0"
 riff-wave = "0.1.3"
 flume = { version = "0.11.0", default-features = false, features = ["async"] }
 rayon = { version = "1.8.1" }
 
 [dev-dependencies]
-ort = "=2.0.0-rc.5"
 rodio = "0.19.0"


### PR DESCRIPTION
Thanks for your work on this project!

I was running into issues compiling and running the crate as a dependency in a project I'm working on. After investigating, it looks like `ort` reorganized its public API in its recent RC. This is a small PR that updates the project to use the most recent version of `ort`.