### PR TITLE
feat: add espeak-ng as an optional feature to replace espeak-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "espeak-ng"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "083cee3337773bfa7f1c38fe022dab392438ced57f3a64c883011952d13b83a1"
+dependencies = [
+ "bitflags 2.11.1",
+ "thiserror",
+]
+
+[[package]]
 name = "espeak-rs"
 version = "0.2.0"
 dependencies = [
@@ -961,6 +971,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 name = "piper-rs"
 version = "0.2.0"
 dependencies = [
+ "espeak-ng",
  "espeak-rs",
  "ndarray 0.16.1",
  "ort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,18 @@ description = "Use piper TTS models in Rust"
 repository = "https://github.com/thewh1teagle/piper-rs"
 
 [dependencies]
-espeak-rs = { path = "crates/espeak-rs", version = "0.2.0", default-features = false }
+espeak-rs = { path = "crates/espeak-rs", version = "0.2.0", default-features = false, optional = true }
 ndarray = "0.16.1"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.89"
 ort = { version = "=2.0.0-rc.12" }
+espeak-ng = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 rodio = "0.19.0"
 
 [features]
-default = ["compile-espeak-intonations"]
+default = ["espeak-rs", "compile-espeak-intonations"]
+espeak-rs = ["dep:espeak-rs"]
+espeak-ng = ["dep:espeak-ng"]
 compile-espeak-intonations = ["espeak-rs/compile-espeak-intonations"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
-use espeak_rs::text_to_phonemes;
 use ort::session::Session;
 use serde_json;
 
@@ -83,9 +82,32 @@ impl Piper {
         let phonemes = if is_phonemes {
             text.to_string()
         } else {
-            text_to_phonemes(text, &self.config.espeak.voice, None)
-                .map_err(|e| PiperError::PhonemizationError(format!("{}", e)))?
-                .join(" ")
+            #[cfg(feature = "espeak-rs")]
+            {
+                use espeak_rs::text_to_phonemes;
+
+                text_to_phonemes(text, &self.config.espeak.voice, None)
+                    .map_err(|e| PiperError::PhonemizationError(format!("{}", e)))?
+                    .join(" ")
+            }
+
+            #[cfg(feature = "espeak-ng")]
+            {
+                use espeak_ng::text_to_ipa;
+
+                text_to_ipa(self.config.espeak.voice.as_str(), text)
+                    .map_err(|e| PiperError::PhonemizationError(format!("{}", e)))?
+            }
+
+            #[cfg(all(feature = "espeak-rs", feature = "espeak-ng"))]
+            {
+                compile_error!("Only use one, espeak-rs or espeak-ng")
+            }
+
+            #[cfg(not(any(feature = "espeak-rs", feature = "espeak-ng")))]
+            {
+                compile_error!("One of espeak-rs or espeak-ng is required")
+            }
         };
 
         let inf = &self.config.inference;


### PR DESCRIPTION
Adds `espeak-ng` as an optional replacement for `espeak-rs`. By default, `espeak-rs` is still used.

I constantly have trouble compiling `espeak-rs`. Then I saw the comment in #26 and decided to try it out and for my use case it works. In that issue, they mentioned that they have some issue with the Rust implementation though, hence it being disabled by default